### PR TITLE
Change link for copyright to ikelax

### DIFF
--- a/userscripts/mensaar-add-uds-htw.user.js
+++ b/userscripts/mensaar-add-uds-htw.user.js
@@ -3,14 +3,14 @@
 // @namespace        https://github.com/ikelax/userscripts
 // @match            https://mensaar.de/
 // @grant            none
-// @version          0.3.0
+// @version          0.3.1
 // @author           Alexander Ikonomou
 // @description      A userscript that adds links to the meal plans of the UdS and HTW to the navigation bar
 // @license          MIT
 // @supportURL       https://github.com/ikelax/userscripts/issues
 // @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/main/userscripts/mensaar-add-uds-htw.user.js
 // @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/main/userscripts/mensaar-add-uds-htw.user.js
-// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax/userscripts)
+// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax)
 // @homepageURL      https://github.com/ikelax/userscripts
 // @homepage         https://github.com/ikelax/userscripts
 // @contributionURL  https://github.com/ikelax/userscripts

--- a/userscripts/mensaar-show-next-day-when-closed.user.js
+++ b/userscripts/mensaar-show-next-day-when-closed.user.js
@@ -3,14 +3,14 @@
 // @namespace        https://github.com/ikelax/userscripts
 // @match            https://mensaar.de/
 // @grant            none
-// @version          0.2.1
+// @version          0.2.2
 // @author           Alexander Ikonomou
 // @description      A userscript that switches to the meal plans for the next day when the canteen has already closed for today
 // @license          MIT
 // @supportURL       https://github.com/ikelax/userscripts/issues
 // @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/main/userscripts/mensaar-show-next-day-when-closed.user.js
 // @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/main/userscripts/mensaar-show-next-day-when-closed.user.js
-// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax/userscripts)
+// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax)
 // @homepageURL      https://github.com/ikelax/userscripts
 // @homepage         https://github.com/ikelax/userscripts
 // @contributionURL  https://github.com/ikelax/userscripts

--- a/userscripts/uds-cms-add-materials.user.js
+++ b/userscripts/uds-cms-add-materials.user.js
@@ -4,14 +4,14 @@
 // @match            https://cms.sic.saarland/*
 // @exclude-match    https://cms.sic.saarland/system/*
 // @grant            none
-// @version          0.3.0
+// @version          0.3.1
 // @author           Alexander Ikonomou
 // @description      A userscript that adds a link to the materials of the current course to the navigation bar
 // @license          MIT
 // @supportURL       https://github.com/ikelax/userscripts/issues
 // @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/main/userscripts/uds-cms-add-materials.user.js
 // @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/main/userscripts/uds-cms-add-materials.user.js
-// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax/userscripts)
+// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax)
 // @homepageURL      https://github.com/ikelax/userscripts
 // @homepage         https://github.com/ikelax/userscripts
 // @contributionURL  https://github.com/ikelax/userscripts


### PR DESCRIPTION
It makes more sense to me link to my GitHub profile after my name.

I consider such documentation issues as bugs and therefore increased the patch version.

Closes: https://github.com/ikelax/userscripts/issues/21