### PR TITLE
Show Next Day for Mensaar does not work any more

### DIFF
--- a/userscripts/mensaar-show-next-day-when-closed.user.js
+++ b/userscripts/mensaar-show-next-day-when-closed.user.js
@@ -21,7 +21,7 @@
 waitForKeyElements("div.active", switchToNextDay);
 
 function switchToNextDay(activeTab) {
-  let activeTabDate = new Date(activeTab);
+  let activeTabDate = new Date(activeTab.innerText);
   let closeDate = new Date(
     activeTabDate.getFullYear(),
     activeTabDate.getMonth(),


### PR DESCRIPTION
For some reason, this worked before without `innerText`. Maybe, the page was changed, or I did not test carefully. The issue was that without `innerText` `new Date(activeTab)` is an `Invalid Date`.

Closes https://github.com/ikelax/userscripts/issues/28.