### PR TITLE
Add userscript for YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Userscripts
 
-Userscripts to add functionality to pages of the Saarland University.
+Here are userscripts I wrote for others and myself. Most of
+them add functionality to pages of the Saarland University.
 
 ## Installation
 
@@ -26,18 +27,21 @@ Userscripts to add functionality to pages of the Saarland University.
      [OpenUserJS](https://openuserjs.org/users/Mottie/scripts)
      (OU).<br><br>
 
-   | Userscript Documentation            |   Direct Install    |            Sites            |
-   | ----------------------------------- | :-----------------: | :-------------------------: |
-   | [Mensaar Navbar UdS HTW][mnuh-docs] | [install][mnuh-raw] | [GF][mnuh-gf] [OU][mnuh-ou] |
-   | [Mensaar Show Next Day][msnd-docs]  | [install][msnd-raw] | [GF][msnd-gf] [OU][msnd-ou] |
-   | [CMS Navbar Materials][cnm-docs]    | [install][cnm-raw]  |  [GF][cnm-gf] [OU][cnm-ou]  |
+   | Userscript Documentation              |   Direct Install    |            Sites            |
+   | ------------------------------------- | :-----------------: | :-------------------------: |
+   | [Mensaar Navbar UdS HTW][mnuh-docs]   | [install][mnuh-raw] | [GF][mnuh-gf] [OU][mnuh-ou] |
+   | [Mensaar Show Next Day][msnd-docs]    | [install][msnd-raw] | [GF][msnd-gf] [OU][msnd-ou] |
+   | [CMS Navbar Materials][cnm-docs]      | [install][cnm-raw]  |  [GF][cnm-gf] [OU][cnm-ou]  |
+   | [YouTube Five Videos in Row][yt-docs] |  [install][yt-raw]  |            GF OU            |
 
 [mnuh-docs]: docs/Mensaar_Navbar_UdS_HTW.md
 [msnd-docs]: docs/Mensaar_Show_Next_Day.md
 [cnm-docs]: docs/CMS_Navbar_Materials.md
+[yt-docs]: docs/YouTube_Five_Videos_in_Row.md
 [mnuh-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/mensaar-add-uds-htw.user.js
 [msnd-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/mensaar-show-next-day-when-closed.user.js
 [cnm-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/uds-cms-add-materials.user.js
+[yt-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/youtube-five-videos-in-row.user.js
 [mnuh-gf]: https://greasyfork.org/en/scripts/533937-mensaar-navbar-uds-htw
 [msnd-gf]: https://greasyfork.org/en/scripts/533989-mensaar-show-next-day
 [cnm-gf]: https://greasyfork.org/en/scripts/533938-cms-navbar-materials

--- a/docs/YouTube_Five_Videos_in_Row.md
+++ b/docs/YouTube_Five_Videos_in_Row.md
@@ -1,0 +1,4 @@
+# YouTube Five Videos in Row
+
+The userscript just changes the style of YouTube's homepage
+such that five videos are shown in a row instead of three.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,12 @@ export default defineConfig([
   },
   {
     files: ["**/*.{js,mjs,cjs}"],
-    languageOptions: { globals: globals.browser },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        GM_addStyle: "readonly",
+      },
+    },
   },
   {
     files: ["**/*.json"],

--- a/userscripts/youtube-five-videos-in-row.user.js
+++ b/userscripts/youtube-five-videos-in-row.user.js
@@ -1,0 +1,34 @@
+// ==UserScript==
+// @name             YouTube Five Videos in Row
+// @namespace        https://github.com/ikelax/userscripts
+// @match            https://www.youtube.com/
+// @grant            none
+// @version          0.1.0
+// @author           Alexander Ikonomou
+// @description      A userscript that changes the style of YouTube's homepage such that five videos are shown in a row instead of three
+// @license          MIT
+// @supportURL       https://github.com/ikelax/userscripts/issues
+// @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/youtube-five-videos-in-row.user.js
+// @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/youtube-five-videos-in-row.user.js
+// @copyright        2025, Alexander Ikonomou (https://github.com/ikelax)
+// @homepageURL      https://github.com/ikelax/userscripts
+// @homepage         https://github.com/ikelax/userscripts
+// @contributionURL  https://github.com/ikelax/userscripts
+// @collaborator     ikelax
+// @icon             https://img.icons8.com/bubbles/100/youtube-squared.png
+// @grant            GM_addStyle
+// @run-at           document-start
+// ==/UserScript==
+
+(() => {
+  "use strict";
+
+  GM_addStyle(
+    `
+      div {
+        --ytd-rich-grid-items-per-row: 5 !important;
+        --ytd-rich-grid-posts-per-row: 5 !important;
+    }
+    `,
+  );
+})();


### PR DESCRIPTION
Because the repository contains does not contain only userscripts for the Saarland University anymore, I adjusted the beginning of the README.

I will add the links for GreasyFork and OpenUserJS after releasing the script there.

I had to adjust the language options for JavaScript in ESLINT because otherwise no_undef is triggered by GM_addStyle.

See also: https://eslint.org/docs/latest/rules/no-undef
See also: https://eslint.org/docs/latest/use/configure/language-options#specifying-globals