### PR TITLE
Fix creation of closeDate

### DIFF
--- a/userscripts/mensaar-show-next-day-when-closed.user.js
+++ b/userscripts/mensaar-show-next-day-when-closed.user.js
@@ -28,21 +28,11 @@ function switchToNextDay(activeTab) {
   }
 
   let activeTabDate = new Date(tabDate);
+  let closeDate = new Date(activeTabDate.getTime() + 14.5 * 60 * 60000); // add 14.5 hours for the time 2:30 pm
+
   let now = new Date();
 
-  if (now - activeTabDate <= 0) {
-    return;
-  }
-
-  let closeDate = new Date(
-    activeTabDate.getFullYear(),
-    activeTabDate.getMonth(),
-    activeTabDate.getDay(),
-    14,
-    30,
-  );
-
-  if (now - closeDate >= 0) {
+  if (now > closeDate) {
     activeTab.nextSibling?.click();
   }
 }


### PR DESCRIPTION
I don't know too much about JavaScript and how it handles dates, but the creation of `closeDate` seems to be wrong.

With the input `"26. May 2025"`, it outputs `Date Thu May 01 2025 14:30:00 GMT+0200 (Central European Summer Time)`.

What seems to work better, albeit admittedly a bit ugly, is:

```
let closeDate = new Date(activeTabDate.getTime() + 14.5 * 60 * 60000); // add 14.5 hours for the time 2:30 pm
```