### PR TITLE
Add navbar entry for HfM

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,24 @@ them add functionality to pages of the Saarland University.
 
    | Userscript Documentation              |   Direct Install    |            Sites            |
    | ------------------------------------- | :-----------------: | :-------------------------: |
-   | [Mensaar Navbar UdS HTW][mnuh-docs]   | [install][mnuh-raw] | [GF][mnuh-gf] [OU][mnuh-ou] |
+   | [Mensaar Navbar Canteens][mnc-docs]   | [install][mnc-raw]  |  [GF][mnc-gf] [OU][mnc-ou]  |
    | [Mensaar Show Next Day][msnd-docs]    | [install][msnd-raw] | [GF][msnd-gf] [OU][msnd-ou] |
    | [CMS Navbar Materials][cnm-docs]      | [install][cnm-raw]  |  [GF][cnm-gf] [OU][cnm-ou]  |
    | [YouTube Five Videos in Row][yt-docs] |  [install][yt-raw]  |   [GF][yt-gf] [OU][yt-ou]   |
 
-[mnuh-docs]: docs/Mensaar_Navbar_UdS_HTW.md
+[mnc-docs]: docs/Mensaar_Navbar_UdS_HTW.md
 [msnd-docs]: docs/Mensaar_Show_Next_Day.md
 [cnm-docs]: docs/CMS_Navbar_Materials.md
 [yt-docs]: docs/YouTube_Five_Videos_in_Row.md
-[mnuh-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/mensaar-add-uds-htw.user.js
+[mnc-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/mensaar-navbar-canteens.user.js
 [msnd-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/mensaar-show-next-day-when-closed.user.js
 [cnm-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/uds-cms-add-materials.user.js
 [yt-raw]: https://github.com/ikelax/userscripts/raw/refs/heads/master/userscripts/youtube-five-videos-in-row.user.js
-[mnuh-gf]: https://greasyfork.org/en/scripts/533937-mensaar-navbar-uds-htw
+[mnc-gf]: https://greasyfork.org/en/scripts/533937-mensaar-navbar-uds-htw
 [msnd-gf]: https://greasyfork.org/en/scripts/533989-mensaar-show-next-day
 [cnm-gf]: https://greasyfork.org/en/scripts/533938-cms-navbar-materials
 [yt-gf]: https://greasyfork.org/en/scripts/534750-youtube-five-videos-in-row
-[mnuh-ou]: https://openuserjs.org/scripts/ikelax/Mensaar_Navbar_UdS_HTW
+[mnc-ou]: https://openuserjs.org/scripts/ikelax/Mensaar_Navbar_UdS_HTW
 [msnd-ou]: https://openuserjs.org/scripts/ikelax/Mensaar_Show_Next_Day
 [cnm-ou]: https://openuserjs.org/scripts/ikelax/CMS_Navbar_Materials
 [yt-ou]: https://openuserjs.org/scripts/ikelax/YouTube_Five_Videos_in_Row

--- a/docs/Mensaar_Navbar_Canteens.md
+++ b/docs/Mensaar_Navbar_Canteens.md
@@ -1,0 +1,8 @@
+# Mensaar Navbar Canteens
+
+A userscript that adds links to the meal plans of the UdS,
+HTW and HfM to the navigation bar.
+
+## Screenshot
+
+![Location of the added links](../images/mnuh.png)

--- a/docs/Mensaar_Navbar_UdS_HTW.md
+++ b/docs/Mensaar_Navbar_UdS_HTW.md
@@ -1,8 +1,0 @@
-# Mensaar Navbar UdS HTW
-
-A userscript that adds links to the meal plans of the UdS
-and HTW to the navigation bar.
-
-## Screenshot
-
-![Location of UdS and HTW links](../images/mnuh.png)

--- a/userscripts/mensaar-navbar-canteens.user.js
+++ b/userscripts/mensaar-navbar-canteens.user.js
@@ -1,15 +1,15 @@
 // ==UserScript==
-// @name             Mensaar Navbar UdS HTW
+// @name             Mensaar Navbar Canteens
 // @namespace        https://github.com/ikelax/userscripts
 // @match            https://mensaar.de/
 // @grant            none
-// @version          0.3.1
+// @version          0.4.0
 // @author           Alexander Ikonomou
-// @description      A userscript that adds links to the meal plans of the UdS and HTW to the navigation bar
+// @description      A userscript that adds links to the meal plans of the UdS, HTW and HfM to the navigation bar
 // @license          MIT
 // @supportURL       https://github.com/ikelax/userscripts/issues
-// @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/mensaar-add-uds-htw.user.js
-// @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/mensaar-add-uds-htw.user.js
+// @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/mensaar-navbar-canteens.user.js
+// @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/mensaar-navbar-canteens.user.js
 // @copyright        2025, Alexander Ikonomou (https://github.com/ikelax)
 // @homepageURL      https://github.com/ikelax/userscripts
 // @homepage         https://github.com/ikelax/userscripts
@@ -26,6 +26,7 @@
 
   addMensa("UdS", "sb");
   addMensa("HTW", "htwcas");
+  addMensa("HfM", "musiksb");
 
   if (navbar != null) {
     return;


### PR DESCRIPTION
The navigation bar entry is for Cafeteria Hochschule für Musik Saar which is usually abbreviated with HfM.

I renamed the documentation file and the userscript because I added a new canteen. Because I do not want to have to rename it everytime I add a new canteen, I chose canteens.

Closes: https://github.com/ikelax/userscripts/issues/35