### PR TITLE
Fix initiliasation of closeDate

### DIFF
--- a/userscripts/mensaar-show-next-day-when-closed.user.js
+++ b/userscripts/mensaar-show-next-day-when-closed.user.js
@@ -3,7 +3,7 @@
 // @namespace        https://github.com/ikelax/userscripts
 // @match            https://mensaar.de/
 // @grant            none
-// @version          0.2.5
+// @version          0.2.6
 // @author           Alexander Ikonomou
 // @description      A userscript that switches to the meal plans for the next day when the canteen has already closed for today
 // @license          MIT
@@ -28,21 +28,16 @@ function switchToNextDay(activeTab) {
   }
 
   let activeTabDate = new Date(tabDate);
-  let now = new Date();
-
-  if (now - activeTabDate <= 0) {
-    return;
-  }
-
   let closeDate = new Date(
     activeTabDate.getFullYear(),
     activeTabDate.getMonth(),
-    activeTabDate.getDay(),
+    activeTabDate.getDate(),
     14,
     30,
   );
+  let now = new Date();
 
-  if (now - closeDate >= 0) {
+  if (now > closeDate) {
     activeTab.nextSibling?.click();
   }
 }


### PR DESCRIPTION
As mentioned in https://github.com/ikelax/userscripts/pull/42, the previous version of closeDate created for "26. May 2025" the Date "Thu May 01 2025 14:30:00 GMT+0200 (Central European Summer Time)". The reason is that getDay() was used instead of getDate(). getDay() "returns the day of the week for this date according to local time, where 0 represents Sunday." getDate() "returns the day of the month for this date according to local time."

I also noticed that the first if clause was not necessary because activeTabDate is on the same day as closeDate but before such that the second condition can never occur when the first occurs.

See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate
See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay
See also: https://github.com/ikelax/userscripts/pull/42
Closes: https://github.com/ikelax/userscripts/issues/39