### PR TITLE
Update OU link for Mensar Navbar Canteens

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ them add functionality to pages of the Saarland University.
 [cnm-gf]: https://greasyfork.org/en/scripts/533938-cms-navbar-materials
 [yt-gf]: https://greasyfork.org/en/scripts/534750-youtube-five-videos-in-row
 [glda-gf]: https://greasyfork.org/en/scripts/537452-github-link-dashboard-avatar
-[mnc-ou]: https://openuserjs.org/scripts/ikelax/Mensaar_Navbar_UdS_HTW
+[mnc-ou]: https://openuserjs.org/scripts/ikelax/Mensaar_Navbar_Canteens
 [msnd-ou]: https://openuserjs.org/scripts/ikelax/Mensaar_Show_Next_Day
 [cnm-ou]: https://openuserjs.org/scripts/ikelax/CMS_Navbar_Materials
 [yt-ou]: https://openuserjs.org/scripts/ikelax/YouTube_Five_Videos_in_Row


### PR DESCRIPTION
I have to update the link because OpenUserJS was not able to sync the userscript after #35.

![image](https://github.com/user-attachments/assets/1bf02291-0389-4367-b69c-cfb31953dfff)
