### PR TITLE
Add tests for Mensaar Show Next Day

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig([
     extends: ["markdown/recommended"],
   },
   {
-    files: ["**/*.js"],
+    files: ["userscripts/**/*.js"],
     plugins: {
       userscripts: {
         rules: userscripts.rules,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "userscripts",
+  "type": "module",
   "version": "0.1.0",
   "description": "Userscripts that are only useful if you study at the Saarland University.",
   "devDependencies": {
@@ -19,7 +20,8 @@
     "prettier:format": "npx prettier . --write",
     "prettier:check": "npx prettier . --check",
     "lint": "npx eslint .",
-    "lint:fix": "npx eslint --fix ."
+    "lint:fix": "npx eslint --fix .",
+    "test": "node --test './tests/**/*.spec.js'"
   },
   "author": "Alexander Ikonomou",
   "license": "MIT",

--- a/tests/getClosingTime.spec.js
+++ b/tests/getClosingTime.spec.js
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { getClosingTime } from "../utils/getClosingTime.js";
+
+describe("The canteen of the Saarland University", () => {
+  it("closes at 14:15 on Fridays", () => {
+    assert.deepStrictEqual(
+      getClosingTime("Freitag, 6. Juni 2025"),
+      new Date(2025, 5, 6, 14, 15),
+    );
+  });
+
+  [
+    ["Montag, 23. September 2024", "Mondays", new Date(2024, 8, 23, 14, 30)],
+    ["Dienstag, 29. Februar 2000", "Tuesdays", new Date(2000, 1, 29, 14, 30)],
+    ["Mittwoch, 15. Oktober 2025", "Wednesdays", new Date(2025, 9, 15, 14, 30)],
+    ["Donnerstag, 7. März 1991", "Thursdays", new Date(1991, 2, 7, 14, 30)],
+  ].forEach(([dateString, weekday, expected]) => {
+    it(`closes at 14:30 on ${weekday}`, () => {
+      assert.deepStrictEqual(getClosingTime(dateString), expected);
+    });
+  });
+});

--- a/utils/getClosingTime.js
+++ b/utils/getClosingTime.js
@@ -1,0 +1,61 @@
+/**
+ * Converts a German date in the format "Weekday, Day. Month
+ * Year" to "Day. Month Year", translating the month into
+ * English.
+ *
+ * @param {string} date The date string to convert
+ * @returns {string | undefined} The converted date string or undefined if the
+ * date string was not in the expected format
+ */
+function convertDate(date) {
+  const germanDate = date.split(", ")[1];
+
+  return germanDate
+    ?.replace("Januar", "January")
+    ?.replace("Februar", "February")
+    ?.replace("März", "March")
+    ?.replace("Mai", "May")
+    ?.replace("Juni", "June")
+    ?.replace("Juli", "July")
+    ?.replace("Oktober", "October")
+    ?.replace("Dezember", "December");
+}
+
+/**
+ * Depending on the weekday, the canteen close at different
+ * times. For the closing times see also the
+ * {@link https://www.stw-saarland.de/gastro/mensa-saarbruecken/ page of the Studentenwerk}.
+ *
+ * The closing time of the canteen is the closing time of
+ * the latest counter. For the canteen at the Saarland
+ * University, this means that it is the closing time of the
+ * counter for Menü 1 and Menü 2.
+ *
+ * `dateString` is expected to be a string in the format
+ * "Weekday, Day. Month Year" in German.
+ *
+ * @param {string} dateString The date string of the day for
+ * which to compute the closing time
+ * @returns {Date | undefined} The closing time of the
+ * canteen for the day or undefined if the date string was
+ * not in the expected format
+ */
+export function getClosingTime(dateString) {
+  const convertedDateString = convertDate(dateString);
+
+  if (convertedDateString === undefined) {
+    return;
+  }
+
+  const convertedDate = new Date(convertedDateString);
+
+  // mensa closes 15 minutes earlier on Fridays
+  let closingMinutes = convertedDate.getDay() == 5 ? 15 : 30;
+  return new Date(
+    convertedDate.getFullYear(),
+    convertedDate.getMonth(),
+    convertedDate.getDate(),
+    14,
+    closingMinutes,
+  );
+}


### PR DESCRIPTION
I extracted the code for computing the closing time to the function `getClosingTime` in `utils/getClosingTime.js` and wrote tests for it.

I added `"type": "module"` to `package.json` since there were warning when running `npm test` because `utils/getClosingTime.js` is an ES module.

Closes: https://github.com/ikelax/userscripts/issues/40