### PR TITLE
Convert tests and utils to CommonJS

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,8 @@ export default defineConfig([
       globals: {
         ...globals.browser,
         GM_addStyle: "readonly",
+        require: "readonly",
+        module: "readonly",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripts",
-  "type": "module",
+  "type": "commonjs",
   "version": "0.1.0",
   "description": "Userscripts that are only useful if you study at the Saarland University.",
   "devDependencies": {

--- a/tests/getClosingTime.spec.js
+++ b/tests/getClosingTime.spec.js
@@ -1,6 +1,11 @@
-import { describe, it } from "node:test";
-import * as assert from "node:assert/strict";
-import { getClosingTime } from "../utils/getClosingTime.js";
+const test = require("node:test");
+const describe = test.describe;
+const it = test.it;
+
+const assert = require("node:assert/strict");
+
+const pkg = require("../utils/getClosingTime.js");
+const getClosingTime = pkg.getClosingTime;
 
 describe("The canteen of the Saarland University", () => {
   it("closes at 14:15 on Fridays", () => {

--- a/utils/getClosingTime.js
+++ b/utils/getClosingTime.js
@@ -40,7 +40,7 @@ function convertDate(date) {
  * canteen for the day or undefined if the date string was
  * not in the expected format
  */
-export function getClosingTime(dateString) {
+function getClosingTime(dateString) {
   const convertedDateString = convertDate(dateString);
 
   if (convertedDateString === undefined) {
@@ -59,3 +59,5 @@ export function getClosingTime(dateString) {
     closingMinutes,
   );
 }
+
+module.exports.getClosingTime = getClosingTime;


### PR DESCRIPTION
With ES modules, I get the following error message in the browser

> SyntaxError: export declarations may only appear at top level of a module

`waitForKeyElements` from CoeJoder does not export the function. I hope that a CommonJS export is not an issue.

See also: https://github.com/CoeJoder/waitForKeyElements.js/blob/master/waitForKeyElements.js