### PR TITLE
Refactor Mensaar Show Next Day

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default defineConfig([
       globals: {
         ...globals.browser,
         GM_addStyle: "readonly",
+        waitForKeyElements: "readonly",
       },
     },
   },

--- a/userscripts/mensaar-show-next-day-when-closed.user.js
+++ b/userscripts/mensaar-show-next-day-when-closed.user.js
@@ -3,10 +3,11 @@
 // @namespace        https://github.com/ikelax/userscripts
 // @match            https://mensaar.de/
 // @grant            none
-// @version          0.2.6
+// @version          0.3.0
 // @author           Alexander Ikonomou
 // @description      A userscript that switches to the meal plans for the next day when the canteen has already closed for today
 // @license          MIT
+// @require          https://cdn.jsdelivr.net/gh/CoeJoder/waitForKeyElements.js@v1.3/waitForKeyElements.js
 // @supportURL       https://github.com/ikelax/userscripts/issues
 // @updateURL        https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/mensaar-show-next-day-when-closed.user.js
 // @downloadURL      https://raw.githubusercontent.com/ikelax/userscripts/refs/heads/master/userscripts/mensaar-show-next-day-when-closed.user.js
@@ -21,107 +22,34 @@
 waitForKeyElements("div.active", switchToNextDay);
 
 function switchToNextDay(activeTab) {
-  const tabDate = convertDate(activeTab.innerText);
+  const tabDate = activeTab.innerText;
 
   if (tabDate == undefined) {
     return;
   }
 
-  let activeTabDate = new Date(tabDate);
-  // mensa closes 15 minutes earlier on Fridays
-  let closingMinutes = activeTabDate.getDay() == 5 ? 15 : 30;
-  let closeDate = new Date(
-    activeTabDate.getFullYear(),
-    activeTabDate.getMonth(),
-    activeTabDate.getDate(),
-    14,
-    closingMinutes,
-  );
-  let now = new Date();
+  const closingTime = getClosingTime(tabDate);
 
-  if (now > closeDate) {
+  if (closingTime === undefined) {
+    return;
+  }
+
+  const now = new Date();
+
+  if (now > closingTime) {
     activeTab.nextSibling?.click();
   }
 }
 
-// The code was copied from https://github.com/CoeJoder/waitForKeyElements.js.
-/**
- * A utility function for userscripts that detects and handles AJAXed content.
+/***********************************************************
  *
- * @example
- * waitForKeyElements("div.comments", (element) => {
- *   element.innerHTML = "This text inserted by waitForKeyElements().";
- * });
+ * The code below is copied from `utils/getClosingTime.js`.
+ * If you make any changes to the code, please copy them to
+ * `utils/getClosingTime.js`.
  *
- * waitForKeyElements(() => {
- *   const iframe = document.querySelector('iframe');
- *   if (iframe) {
- *     const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
- *     return iframeDoc.querySelectorAll("div.comments");
- *   }
- *   return null;
- * }, callbackFunc);
+ * For the reasons, see commit c47a8305a7a5163d638becc2c169.
  *
- * @param {(string|function)} selectorOrFunction - The selector string or function.
- * @param {function}          callback           - The callback function; takes a single DOM element as parameter.
- *                                                 If returns true, element will be processed again on subsequent iterations.
- * @param {boolean}           [waitOnce=true]    - Whether to stop after the first elements are found.
- * @param {number}            [interval=300]     - The time (ms) to wait between iterations.
- * @param {number}            [maxIntervals=-1]  - The max number of intervals to run (negative number for unlimited).
- */
-function waitForKeyElements(
-  selectorOrFunction,
-  callback,
-  waitOnce,
-  interval,
-  maxIntervals,
-) {
-  if (typeof waitOnce === "undefined") {
-    waitOnce = true;
-  }
-  if (typeof interval === "undefined") {
-    interval = 300;
-  }
-  if (typeof maxIntervals === "undefined") {
-    maxIntervals = -1;
-  }
-  if (typeof waitForKeyElements.namespace === "undefined") {
-    waitForKeyElements.namespace = Date.now().toString();
-  }
-  var targetNodes =
-    typeof selectorOrFunction === "function"
-      ? selectorOrFunction()
-      : document.querySelectorAll(selectorOrFunction);
-
-  var targetsFound = targetNodes && targetNodes.length > 0;
-  if (targetsFound) {
-    targetNodes.forEach(function (targetNode) {
-      var attrAlreadyFound = `data-userscript-${waitForKeyElements.namespace}-alreadyFound`;
-      var alreadyFound = targetNode.getAttribute(attrAlreadyFound) || false;
-      if (!alreadyFound) {
-        var cancelFound = callback(targetNode);
-        if (cancelFound) {
-          targetsFound = false;
-        } else {
-          targetNode.setAttribute(attrAlreadyFound, true);
-        }
-      }
-    });
-  }
-
-  if (maxIntervals !== 0 && !(targetsFound && waitOnce)) {
-    maxIntervals -= 1;
-    setTimeout(function () {
-      waitForKeyElements(
-        selectorOrFunction,
-        callback,
-        waitOnce,
-        interval,
-        maxIntervals,
-      );
-    }, interval);
-  }
-}
+ **********************************************************/
 
 /**
  * Converts a German date in the format "Weekday, Day. Month
@@ -129,7 +57,8 @@ function waitForKeyElements(
  * English.
  *
  * @param {string} date The date string to convert
- * @returns The converted date string
+ * @returns {string | undefined} The converted date string or undefined if the
+ * date string was not in the expected format
  */
 function convertDate(date) {
   const germanDate = date.split(", ")[1];
@@ -143,4 +72,43 @@ function convertDate(date) {
     ?.replace("Juli", "July")
     ?.replace("Oktober", "October")
     ?.replace("Dezember", "December");
+}
+
+/**
+ * Depending on the weekday, the canteen close at different
+ * times. For the closing times see also the
+ * {@link https://www.stw-saarland.de/gastro/mensa-saarbruecken/ page of the Studentenwerk}.
+ *
+ * The closing time of the canteen is the closing time of
+ * the latest counter. For the canteen at the Saarland
+ * University, this means that it is the closing time of the
+ * counter for Menü 1 and Menü 2.
+ *
+ * `dateString` is expected to be a string in the format
+ * "Weekday, Day. Month Year" in German.
+ *
+ * @param {string} dateString The date string of the day for
+ * which to compute the closing time
+ * @returns {Date | undefined} The closing time of the
+ * canteen for the day or undefined if the date string was
+ * not in the expected format
+ */
+function getClosingTime(dateString) {
+  const convertedDateString = convertDate(dateString);
+
+  if (convertedDateString === undefined) {
+    return;
+  }
+
+  const convertedDate = new Date(convertedDateString);
+
+  // mensa closes 15 minutes earlier on Fridays
+  let closingMinutes = convertedDate.getDay() == 5 ? 15 : 30;
+  return new Date(
+    convertedDate.getFullYear(),
+    convertedDate.getMonth(),
+    convertedDate.getDate(),
+    14,
+    closingMinutes,
+  );
 }


### PR DESCRIPTION
I refactored `switchToNextDay` with `utils/getClosingTime.js`. `getClosingTime` was implemented in #52 and is basically just the code from `switchToNextDay` extracted into a function.

`waitForKeyElements` was removed because it is also possible to just load the code with the `@require` keyword. This URL is from its README. The advantage of this approach is that it is not necessary any more to manually update the code.

Also, I bumped the minor version since we forgot this in #47.

See also: https://github.com/CoeJoder/waitForKeyElements.js