### PR TITLE
Add job for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Spell Check Repo
         uses: crate-ci/typos@v1.32.0
   js:
-    name: Check linting and formatting
+    name: Check formatting and linting and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,5 +33,7 @@ jobs:
         run: npm clean-install
       - name: Check formatting with Prettier
         run: npm run prettier:check
-      - name: Code linting with ESLint
+      - name: Check linting with ESLint
         run: npm run lint
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: npm clean-install
       - name: Check formatting with Prettier


### PR DESCRIPTION
Glob is supported since Node.js version 21. So, I upgraded it directly to 24.

See also: https://github.com/nodejs/node/issues/50658#issuecomment-1806581766